### PR TITLE
remove lib from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 npm-debug.log
 coverage
-lib
 .idea
 *.iml
 .vscode


### PR DESCRIPTION
@raymondfeng PTAL.. For some reason 'lib' was in .gitignore and when we published to npm, it didn't add 'lib' directory to published version. I realized this while testing 'npm's published version of this module. I can go ahead and publish 1.0.1 version once you review this.