### PR TITLE
New tests

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -9,8 +9,26 @@ var ejs = require('ejs');
 var util = require('util');
 var _cloneDeep = require('lodash').cloneDeep;
 var _s = require('underscore.string');
-
 var template = require('./model-template');
+
+var XML_NUMERIC_TYPES = [  //TODO [rashmi] should all these represent 'number' in loopback?
+  'int',
+  'long',
+  'float',
+  'double',
+  'decimal',
+  'short',
+  'byte',
+  'negativeInteger',
+  'nonNegativeInteger',
+  'nonPositiveInteger',
+  'positiveInteger',
+  'short',
+  'unsignedLong',
+  'unsignedInt',
+  'unsignedShort',
+  'unsignedByte'
+];
 
 function BaseGenerator(options) {
   this.options = options || {};
@@ -275,13 +293,14 @@ function buildElementProperties(models, modelName, propertyList, outerElem, sche
 
     var propertyData;
     var modName;
+
     if (!element.type && !element.isSimple) {
       modName = element.qname.name;
       buildElementProperties(models, modName, {}, element, schemaTypes);
-            // check refOriginal since 'type' is retuned as 'undefined' if it's referenced in a nested imported schema
+      // check refOriginal since 'type' is returned as 'undefined' if it's referenced in a nested imported schema
       if (element.refOriginal) {
         propertyData = {
-          type: element.refOriginal.qname.name,
+          type: checkAndConvertToNumber(element.refOriginal.qname.name),
         };
         propertyList[element.qname.name] = propertyData;
       }
@@ -292,16 +311,16 @@ function buildElementProperties(models, modelName, propertyList, outerElem, sche
       if (schemaTypes.simpleTypes && schemaTypes.simpleTypes[element.type.name]) {
         type = schemaTypes.simpleTypes[element.type.name].children[0].base.$name;
       } else {
-                // could be a complextype or xs: simple type
+        // could be a complextype or xs: simple type
         type = element.type.name;
       }
     }
     propertyData = {
-      type: type,
+      type: checkAndConvertToNumber(type),
     };
     propertyList[element.qname.name] = propertyData;
 
-    if (!element.isSimple) {
+    if (element.elements.length != 0) {
       modName = element.type.name;
       buildElementProperties(models, modName, {}, element, schemaTypes);
     }
@@ -330,17 +349,6 @@ function getOperations(spec) {
       op.verb = verb.toLowerCase();
       op.path = path.replace(/{(([^{}])+)}/g, ':$1');
 
-            // operationId is optional
-      if (!op.operationId) {
-                // Derive the operationId from verb & path
-        op.operationId = op.verb.toLowerCase() + '_' + op.path;
-      }
-
-            // Camelize the operation id
-      op.operationId = op.operationId.replace(/{(([^{}])+)}/g, '_$1');
-      op.operationId = _s.camelize(
-                op.operationId.split(/[\.\s\/-:\*]+/).join('_'));
-
       var operation = new BaseOperation(op);
       operation.getRemoting();
 
@@ -354,10 +362,8 @@ function getOperations(spec) {
 
 // get remote method parameter/s in a specific format needed for code generation in model.ejs template
 function mapParameter(p) {
-  var type = p.type;
-  if (p.type === 'integer') {
-    type = 'number';
-  }
+  var type = checkAndConvertToNumber(p.type);
+
   if (p.type === 'array' && p.items) {
     type = [p.items.type || this.resolveTypeRef(p.items.$ref)];
   }
@@ -426,4 +432,11 @@ function printParams(op) {
   return params.join('\n');
 }
 
+function checkAndConvertToNumber(typeName) {
+  if (XML_NUMERIC_TYPES.indexOf(typeName.toLowerCase()) !== -1) {
+    return 'number';
+  } else {
+    return typeName;
+  }
+};
 module.exports = BaseGenerator;

--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -11,7 +11,8 @@ var _cloneDeep = require('lodash').cloneDeep;
 var _s = require('underscore.string');
 var template = require('./model-template');
 
-var XML_NUMERIC_TYPES = [  //TODO [rashmi] should all these represent 'number' in loopback?
+// TODO [rashmi] should all these represent 'number' in loopback?
+var XML_NUMERIC_TYPES = [
   'int',
   'long',
   'float',
@@ -27,7 +28,7 @@ var XML_NUMERIC_TYPES = [  //TODO [rashmi] should all these represent 'number' i
   'unsignedLong',
   'unsignedInt',
   'unsignedShort',
-  'unsignedByte'
+  'unsignedByte',
 ];
 
 function BaseGenerator(options) {

--- a/test/results/anytype_model.json
+++ b/test/results/anytype_model.json
@@ -19,5 +19,65 @@
     "name": "GetInfoByAreaCodeResult",
     "properties": {
     }
+  },
+  "GetInfoByCity": {
+    "name": "GetInfoByCity",
+    "properties": {
+      "USCity": {
+        "type": "string"
+      }
+    }
+  },
+  "GetInfoByCityResponse": {
+    "name": "GetInfoByCityResponse",
+    "properties": {
+      "GetInfoByCityResult": {
+        "type": "GetInfoByCityResult"
+      }
+    }
+  },
+  "GetInfoByCityResult": {
+    "name": "GetInfoByCityResult",
+    "properties": {}
+  },
+  "GetInfoByState": {
+    "name": "GetInfoByState",
+    "properties": {
+      "USState": {
+        "type": "string"
+      }
+    }
+  },
+  "GetInfoByStateResponse": {
+    "name": "GetInfoByStateResponse",
+    "properties": {
+      "GetInfoByStateResult": {
+        "type": "GetInfoByStateResult"
+      }
+    }
+  },
+  "GetInfoByStateResult": {
+    "name": "GetInfoByStateResult",
+    "properties": {}
+  },
+  "GetInfoByZIP": {
+    "name": "GetInfoByZIP",
+    "properties": {
+      "USZip": {
+        "type": "string"
+      }
+    }
+  },
+  "GetInfoByZIPResponse": {
+    "name": "GetInfoByZIPResponse",
+    "properties": {
+      "GetInfoByZIPResult": {
+        "type": "GetInfoByZIPResult"
+      }
+    }
+  },
+  "GetInfoByZIPResult": {
+    "name": "GetInfoByZIPResult",
+    "properties": {}
   }
 }

--- a/test/results/opname_withnumber_model.json
+++ b/test/results/opname_withnumber_model.json
@@ -1,0 +1,18 @@
+{
+  "GetICD9Level2": {
+    "name": "GetICD9Level2",
+    "properties": {
+      "ICD9Level1ID": {
+        "type": "number"
+      }
+    }
+  },
+  "GetICD9Level2Response": {
+    "name": "GetICD9Level2Response",
+    "properties": {
+      "GetICD9Level2Result": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/test/results/recursive_model.json
+++ b/test/results/recursive_model.json
@@ -30,6 +30,12 @@
       "Address": {
         "type": "string"
       },
+      "Zip": {
+        "type": "number"
+      },
+      "Latitude": {
+        "type": "number"
+      },
       "Email": {
         "type": "string"
       },

--- a/test/results/rpc_literal_model.json
+++ b/test/results/rpc_literal_model.json
@@ -3,10 +3,10 @@
     "name": "myMethod",
     "properties": {
       "x": {
-        "type": "int"
+        "type": "number"
       },
       "y": {
-        "type": "float"
+        "type": "number"
       }
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -256,11 +256,11 @@ describe('Generate APIs and models with WSDLs containing ', function() {
         function(err, wsdl) {
           var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByAreaCode; // eslint-disable-line max-len
           operations.push(operation);
-          var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByCity; // eslint-disable-line max-len
+          operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByCity; // eslint-disable-line max-len
           operations.push(operation);
-          var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByState; // eslint-disable-line max-len
+          operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByState; // eslint-disable-line max-len
           operations.push(operation);
-          var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByZIP; // eslint-disable-line max-len
+          operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByZIP; // eslint-disable-line max-len
           operations.push(operation);
           loadedWsdl = wsdl;
           var apiData = {
@@ -280,7 +280,7 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           var index = code.indexOf('USZipUSZipSoap12.GetInfoByAreaCode = function(GetInfoByAreaCode, callback)'); // eslint-disable-line max-len
           assert.ok(index > -1);
             // check for beginning of REST API in generated code
-          index = code.indexOf("USZipUSZipSoap12.GetInfoByState = function(GetInfoByState, callback)");
+          index = code.indexOf('USZipUSZipSoap12.GetInfoByState = function(GetInfoByState, callback)'); // eslint-disable-line max-len
           assert.ok(index > -1);
 
           // check for beginning of REST API in generated code
@@ -298,45 +298,44 @@ describe('Generate APIs and models with WSDLs containing ', function() {
         });
   });
 
-  it("Operation Name has a number and property has numeric type", function(done) {
-        var options = {};
-        var operations = [];
-        var loadedWsdl;
-        var url = 'http://www.webservicex.net/icd9.asmx?WSDL';
+  it('Operation Name has a number and property has numeric type', function(done) {
+    var options = {};
+    var operations = [];
+    var loadedWsdl;
+    var url = 'http://www.webservicex.net/icd9.asmx?WSDL';
 
-        WSDL.open(url, options,
-            function(err, wsdl) {
-                var operation = wsdl.definitions.bindings.ICD9Soap.operations.GetICD9Level2; // eslint-disable-line max-len
-                operations.push(operation);
-                loadedWsdl = wsdl;
-                var apiData = {
-                    'wsdl': wsdl,
-                    'wsdlUrl': url,
-                    'service': 'ICD9',
-                    'binding': 'ICD9Soap',
-                    'operations': operations,
-                };
+    WSDL.open(url, options,
+        function(err, wsdl) {
+          var operation = wsdl.definitions.bindings.ICD9Soap.operations.GetICD9Level2; // eslint-disable-line max-len
+          operations.push(operation);
+          loadedWsdl = wsdl;
+          var apiData = {
+            'wsdl': wsdl,
+            'wsdlUrl': url,
+            'service': 'ICD9',
+            'binding': 'ICD9Soap',
+            'operations': operations,
+          };
 
-                var code = helper.generateRemoteMethods(apiData);
-                var generatedModels = helper.generateModels(wsdl, operations);
+          var code = helper.generateRemoteMethods(apiData);
+          var generatedModels = helper.generateModels(wsdl, operations);
 
-                // check for API/operation signature in generated code
-                var index = code.indexOf('ICD9ICD9Soap.GetICD9Level2 = function(GetICD9Level2, callback)'); // eslint-disable-line max-len
-                assert.ok(index > -1);
-                // check for beginning of REST API in generated code
-                index = code.indexOf("ICD9ICD9Soap.remoteMethod('GetICD9Level2'");
-                assert.ok(index > -1);
+          // check for API/operation signature in generated code
+          var index = code.indexOf('ICD9ICD9Soap.GetICD9Level2 = function(GetICD9Level2, callback)'); // eslint-disable-line max-len
+          assert.ok(index > -1);
+          // check for beginning of REST API in generated code
+          index = code.indexOf("ICD9ICD9Soap.remoteMethod('GetICD9Level2',");
+          assert.ok(index > -1);
 
-                var expectedModels = readModelJsonSync('opname_withnumber_model.json');
-                expect(generatedModels).to.deep.equal(expectedModels);
+          var expectedModels = readModelJsonSync('opname_withnumber_model.json');
+          expect(generatedModels).to.deep.equal(expectedModels);
 
-                done();
-            });
-    });
-
+          done();
+        });
+  });
 });
 
 function readModelJsonSync(name) {
-    var modelJson = path.resolve(__dirname, 'results',  name);
-    return JSON.parse(fs.readFileSync(modelJson));
+  var modelJson = path.resolve(__dirname, 'results',  name);
+  return JSON.parse(fs.readFileSync(modelJson));
 }

--- a/test/test.js
+++ b/test/test.js
@@ -98,7 +98,7 @@ describe('Generate APIs and models with WSDLs containing ', function() {
   });
 
     // skipping this until a fix made in strong-soap gets into master and published to npm
-  it.skip('RPC/Literal', function(done) {
+  it('RPC/Literal', function(done) {
     var options = {};
     var operations = [];
     var loadedWsdl;
@@ -256,6 +256,12 @@ describe('Generate APIs and models with WSDLs containing ', function() {
         function(err, wsdl) {
           var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByAreaCode; // eslint-disable-line max-len
           operations.push(operation);
+          var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByCity; // eslint-disable-line max-len
+          operations.push(operation);
+          var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByState; // eslint-disable-line max-len
+          operations.push(operation);
+          var operation = wsdl.definitions.bindings.USZipSoap12.operations.GetInfoByZIP; // eslint-disable-line max-len
+          operations.push(operation);
           loadedWsdl = wsdl;
           var apiData = {
             'wsdl': wsdl,
@@ -266,17 +272,23 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           };
 
           var code = helper.generateRemoteMethods(apiData);
-          console.log(code);
 
           // TODO [rashmi] Revisit. Currently strong-soap returns xs:any type as 0 element which results in empty properties {} list in the model.
           var generatedModels = helper.generateModels(wsdl, operations);
-          console.log(util.inspect(generatedModels, {depth: null}));
 
             // check for API/operation signature in generated code
           var index = code.indexOf('USZipUSZipSoap12.GetInfoByAreaCode = function(GetInfoByAreaCode, callback)'); // eslint-disable-line max-len
           assert.ok(index > -1);
             // check for beginning of REST API in generated code
-          index = code.indexOf("USZipUSZipSoap12.remoteMethod('GetInfoByAreaCode',");
+          index = code.indexOf("USZipUSZipSoap12.GetInfoByState = function(GetInfoByState, callback)");
+          assert.ok(index > -1);
+
+          // check for beginning of REST API in generated code
+          index = code.indexOf("USZipUSZipSoap12.remoteMethod('GetInfoByState',");
+          assert.ok(index > -1);
+
+          // check for beginning of REST API in generated code
+          index = code.indexOf("type: 'GetInfoByState'");
           assert.ok(index > -1);
 
           var expectedModels = readModelJsonSync('anytype_model.json');
@@ -285,10 +297,46 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           done();
         });
   });
+
+  it("Operation Name has a number and property has numeric type", function(done) {
+        var options = {};
+        var operations = [];
+        var loadedWsdl;
+        var url = 'http://www.webservicex.net/icd9.asmx?WSDL';
+
+        WSDL.open(url, options,
+            function(err, wsdl) {
+                var operation = wsdl.definitions.bindings.ICD9Soap.operations.GetICD9Level2; // eslint-disable-line max-len
+                operations.push(operation);
+                loadedWsdl = wsdl;
+                var apiData = {
+                    'wsdl': wsdl,
+                    'wsdlUrl': url,
+                    'service': 'ICD9',
+                    'binding': 'ICD9Soap',
+                    'operations': operations,
+                };
+
+                var code = helper.generateRemoteMethods(apiData);
+                var generatedModels = helper.generateModels(wsdl, operations);
+
+                // check for API/operation signature in generated code
+                var index = code.indexOf('ICD9ICD9Soap.GetICD9Level2 = function(GetICD9Level2, callback)'); // eslint-disable-line max-len
+                assert.ok(index > -1);
+                // check for beginning of REST API in generated code
+                index = code.indexOf("ICD9ICD9Soap.remoteMethod('GetICD9Level2'");
+                assert.ok(index > -1);
+
+                var expectedModels = readModelJsonSync('opname_withnumber_model.json');
+                expect(generatedModels).to.deep.equal(expectedModels);
+
+                done();
+            });
+    });
+
 });
 
 function readModelJsonSync(name) {
-  var modelJson = path.resolve(__dirname, 'results',  name);
-  expect(fs.existsSync(modelJson), 'file exists');
-  return JSON.parse(fs.readFileSync(modelJson));
+    var modelJson = path.resolve(__dirname, 'results',  name);
+    return JSON.parse(fs.readFileSync(modelJson));
 }

--- a/test/wsdls/recursive/B.xsd
+++ b/test/wsdls/recursive/B.xsd
@@ -27,6 +27,10 @@
             </xs:element>
             <xs:element name="Address" type="xs:string" minOccurs="0"
                         maxOccurs="1"/>
+            <xs:element name="Zip" type="xs:int" minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element name="Latitude" type="xs:float" minOccurs="0"
+                        maxOccurs="1"/>
             <xs:element name="Email" type="xs:string" minOccurs="0"
                         maxOccurs="1"/>
             <xs:element name="Telephone" type="xs:string" minOccurs="0"


### PR DESCRIPTION
This PR 1) Enables RPC/Literal test case 2) Removes operation name mangling logic as this is not needed for soap 3) supports conversion of xml numeric types to loopback 'number' type 4) test cases for both of these. @raymondfeng PTAL
 