### PR TITLE
Handle special char in service/binding

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -113,10 +113,19 @@ BaseGenerator.prototype.generateRemoteMethods = function(opsInfo, options) {
     }
   }
   var modelName = opsInfo.service + opsInfo.binding;
+  // modeName is used as variable name in the generated code. Hence need to replace -,.,/ with _
+  modelName = normalizeVarName(modelName);
   var code = generateCodeForOperations(modelName, opsInfo.datasource,
     operationList);
   return code;
 };
+
+function normalizeVarName(modelName) {
+  // since the generated javascript code uses servicename+bindinganme as variable name for created model, if this
+  // name contains any special characters not acceptable for javascript variable name, substitute these
+  // special characters with _
+  return modelName.replace(/[-.\/`~!@#%^&*()-+={}'";:<>,?/]/g, '_');
+}
 
 /**
  * Given list of operations from user via loopback-cli/generator-loopback, this method generates models needed for the remote methods

--- a/test/test.js
+++ b/test/test.js
@@ -101,7 +101,6 @@ describe('Generate APIs and models with WSDLs containing ', function() {
         });
   });
 
-    // skipping this until a fix made in strong-soap gets into master and published to npm
   it('RPC/Literal', function(done) {
     var options = {};
     var operations = [];
@@ -379,6 +378,39 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           assert.ok(index > -1);
           index = code.indexOf('ICD9ICD9Soap.GetICD9Level2(GetICD9Level2, function (err, response)'); // eslint-disable-line max-len
           assert.ok(index > -1);
+          done();
+        });
+  });
+
+  it('Special character in binding or service name', function(done) {
+    var options = {};
+    var operations = [];
+    var loadedWsdl;
+    var url = './wsdls/special_char_test.wsdl';
+
+    WSDL.open(path.resolve(__dirname, url), options,
+        function(err, wsdl) {
+          var bindings = wsdl.definitions.bindings;
+          var myMethod =
+                bindings["-a.b/c`d~e!f@g#h%i^j*k(l)m-n+o=p'q+r;s<t>u,v?w/x"].operations.myMethod;
+          operations.push(myMethod);
+          loadedWsdl = wsdl;
+          var apiData = {
+            // assumes SOAP WebService datasource with name 'soapDS' exists
+            'datasource': 'soapDS',
+            'wsdl': wsdl,
+            'wsdlUrl': url,
+            'service': 'RPCLiteralService',
+            'binding': "-a.b/c`d~e!f@g#h%i^j*k(l)m-n+o=p'q+r;s<t>u,v?w/x",
+            'operations': operations,
+          };
+
+          var code = helper.generateRemoteMethods(apiData);
+
+          // check variable name for the model is created correctly by substituting any special characters not acceptable in javascript variable with _
+          var index = code.indexOf('var RPCLiteralService_a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x;'); // eslint-disable-line max-len
+          assert.ok(index > -1);
+
           done();
         });
   });

--- a/test/wsdls/special_char_test.wsdl
+++ b/test/wsdls/special_char_test.wsdl
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!-- rpc/Literal example -->
+
+<wsdl:definitions name="StockQuoteRPCLiteral"
+                  targetNamespace="http://example.com/rpc_Literal_test.wsdl"
+                  xmlns:tns="http://example.com/rpc_literal_test.wsdl"
+                  xmlns:xsd1="http://example.com/rpc_literal_test.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+
+    <wsdl:message name="myMethodRequest">
+        <wsdl:part name="x" type="xsd:int"/>
+        <wsdl:part name="y" type="xsd:float"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="RPCLiteralTest">
+        <wsdl:operation name="myMethod">
+            <wsdl:input message="tns:myMethodRequest"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+
+    <wsdl:binding name="-a.b/c`d~e!f@g#h%i^j*k(l)m-n+o=p'q+r;s<t>u,v?w/x" type="tns:RPCLiteralTest">
+        <soap:binding style="rpc"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="myMethod">
+            <soap:operation soapAction="http://example.com/RPCLiteralTest"/>
+            <wsdl:input>
+                <soap:body/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="RPCLiteralService">
+        <wsdl:port name="RpcLiteralTestPort" binding="tns:-a.b/c`d~e!f@g#h%i^j*k(l)m-n+o=p'q+r;s<t>u,v?w/x">
+            <soap:address location="http://localhost:15099/rpc_Literal_testing"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>
+


### PR DESCRIPTION
There are 2 bugs in this issue https://github.com/strongloop/loopback-connector-soap/issues/78 
and the first issue is fixed in this repository. We use servicename+bindingname as model variable name in generated API code and if special characters are present (e.g '.') which are not acceptable in javascript variable name, then, the generated API code will have errors.  This PR replaces special characters with underscore '_' . Also added test to cover this use case.
@raymondfeng PTAL