### PR TITLE
Slight fix for some more complex wsdl scenarios

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -311,16 +311,20 @@ function buildElementProperties(models, modelName, propertyList, outerElem, sche
         // if simpleType, check in simpleTypes list. For e.g Enum could be of simpleType, but not xs: simple type
     if (element.type) {
       if (schemaTypes.simpleTypes && schemaTypes.simpleTypes[element.type.name]) {
-        type = schemaTypes.simpleTypes[element.type.name].children[0].base.$name;
+        if(schemaTypes.simpleTypes[element.type.name].union){ 
+          type = schemaTypes.simpleTypes[element.type.name].union.children[0].children[0].base.$name 
+        } else {
+          type = schemaTypes.simpleTypes[element.type.name].children[0].base.$name;
+        }
       } else {
         // could be a complextype or xs: simple type
         type = element.type.name;
       }
+      propertyData = {
+        type: checkAndConvertToNumber(type),
+      };
+      propertyList[element.qname.name] = propertyData;
     }
-    propertyData = {
-      type: checkAndConvertToNumber(type),
-    };
-    propertyList[element.qname.name] = propertyData;
 
     if (element.elements.length != 0) {
       modName = element.type.name;


### PR DESCRIPTION
- Handling unions
- Do not use ```type``` in the scenario where it will be equal to ```undefined```

Attached the sample wsdl I am using from Cisco call manager.
[wsdl.zip](https://github.com/strongloop/loopback-soap/files/2014079/wsdl.zip)

This should resolve the issue in loopback posted here: https://github.com/strongloop/loopback/issues/3881