### PR TITLE
Fix test cases that uses ICD9 wsdl

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^8.0.0",
     "loopback": "^3.0.0",
-    "mocha": "^3.2.0"
+    "mocha": "^5.2.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/results/opname_withnumber_model.json
+++ b/test/results/opname_withnumber_model.json
@@ -1,18 +1,77 @@
 {
-  "GetICD9Level2": {
-    "name": "GetICD9Level2",
+  "CheckAddressW2lines": {
+    "name": "CheckAddressW2lines",
     "properties": {
-      "ICD9Level1ID": {
-        "type": "number"
-      }
+      "AddressLine": { "type": "string" },
+      "AddressLine2": { "type": "string" },
+      "ZipCode": { "type": "string" },
+      "City": { "type": "string" },
+      "StateAbbrev": { "type": "string" },
+      "LicenseKey": { "type": "string" }
     }
   },
-  "GetICD9Level2Response": {
-    "name": "GetICD9Level2Response",
+  "CheckAddressW2linesResponse": {
+    "name": "CheckAddressW2linesResponse",
+    "properties": { "CheckAddressW2linesResult": { "type": "Address" } }
+  },
+  "Address": {
+    "name": "Address",
     "properties": {
-      "GetICD9Level2Result": {
-        "type": "string"
-      }
+      "ServiceError": { "type": "boolean" },
+      "AddressError": { "type": "boolean" },
+      "AddressFoundBeMoreSpecific": { "type": "boolean" },
+      "CheckDigit": { "type": "number" },
+      "NeededCorrection": { "type": "boolean" },
+      "FromLongitude": { "type": "number" },
+      "FromLatitude": { "type": "number" },
+      "ToLongitude": { "type": "number" },
+      "ToLatitude": { "type": "number" },
+      "AvgLongitude": { "type": "number" },
+      "AvgLatitude": { "type": "number" },
+      "hasDaylightSavings": { "type": "boolean" },
+      "LLCertainty": { "type": "number" },
+      "CountyNum": { "type": "number" },
+      "Firm": { "type": "string" },
+      "DeliveryAddress": { "type": "string" },
+      "DeliveryAddress2": { "type": "string" },
+      "PrimaryLow": { "type": "string" },
+      "PrimaryHigh": { "type": "string" },
+      "PriEO": { "type": "string" },
+      "SecEO": { "type": "string" },
+      "SecondaryLow": { "type": "string" },
+      "SecondaryHigh": { "type": "string" },
+      "Secondary": { "type": "string" },
+      "Extra": { "type": "string" },
+      "City": { "type": "string" },
+      "StateAbbrev": { "type": "string" },
+      "ZipCode": { "type": "string" },
+      "CarrierRoute": { "type": "string" },
+      "County": { "type": "string" },
+      "DeliveryPoint": { "type": "string" },
+      "BarCode": { "type": "string" },
+      "CSKey": { "type": "string" },
+      "UpdateKey": { "type": "string" },
+      "RecordTypeCode": { "type": "string" },
+      "CongressDistrictNumber": { "type": "string" },
+      "FIPS": { "type": "string" },
+      "FinanceNumber": { "type": "string" },
+      "CMSA": { "type": "string" },
+      "PMSA": { "type": "string" },
+      "MSA": { "type": "string" },
+      "MA": { "type": "string" },
+      "TimeZone": { "type": "string" },
+      "AreaCode": { "type": "string" },
+      "PreferredCityName": { "type": "string" },
+      "CensusBlockNum": { "type": "string" },
+      "CensusTractNum": { "type": "string" },
+      "Primary": { "type": "string" },
+      "PrefixDirection": { "type": "string" },
+      "StreetName": { "type": "string" },
+      "Suffix": { "type": "string" },
+      "PostDirection": { "type": "string" },
+      "SecondaryNumber": { "type": "string" },
+      "StateLegislativeUpper": { "type": "string" },
+      "StateLegislativeLower": { "type": "string" }
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -315,11 +315,11 @@ describe('Generate APIs and models with WSDLs containing ', function() {
     var options = {};
     var operations = [];
     var loadedWsdl;
-    var url = 'http://www.webservicex.net/icd9.asmx?WSDL';
+    var url = 'http://ws.cdyne.com/psaddress/addresslookup.asmx?wsdl';
 
     WSDL.open(url, options,
         function(err, wsdl) {
-          var operation = wsdl.definitions.bindings.ICD9Soap.operations.GetICD9Level2; // eslint-disable-line max-len
+          var operation = wsdl.definitions.bindings.AddressLookupSoap.operations.CheckAddressW2lines; // eslint-disable-line max-len
           operations.push(operation);
           loadedWsdl = wsdl;
           var apiData = {
@@ -327,8 +327,8 @@ describe('Generate APIs and models with WSDLs containing ', function() {
             'datasource': 'soapDS',
             'wsdl': wsdl,
             'wsdlUrl': url,
-            'service': 'ICD9',
-            'binding': 'ICD9Soap',
+            'service': 'AddressLookup',
+            'binding': 'AddressLookupSoap',
             'operations': operations,
           };
 
@@ -336,12 +336,11 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           var generatedModels = helper.generateModels(wsdl, operations);
 
           // check for API/operation signature in generated code
-          var index = code.indexOf('ICD9ICD9Soap.GetICD9Level2 = function(GetICD9Level2, callback)'); // eslint-disable-line max-len
+          var index = code.indexOf('AddressLookupSoap.CheckAddressW2lines = function(CheckAddressW2lines, callback)'); // eslint-disable-line max-len
           assert.ok(index > -1);
           // check for beginning of REST API in generated code
-          index = code.indexOf("ICD9ICD9Soap.remoteMethod('GetICD9Level2',");
+          index = code.indexOf("AddressLookupSoap.remoteMethod('CheckAddressW2lines',");
           assert.ok(index > -1);
-
           var expectedModels = readModelJsonSync('opname_withnumber_model.json');
           expect(generatedModels).to.deep.equal(expectedModels);
 
@@ -352,11 +351,11 @@ describe('Generate APIs and models with WSDLs containing ', function() {
     var options = {};
     var operations = [];
     var loadedWsdl;
-    var url = 'http://www.webservicex.net/icd9.asmx?WSDL';
+    var url = 'http://ws.cdyne.com/psaddress/addresslookup.asmx?wsdl';
 
     WSDL.open(url, options,
         function(err, wsdl) {
-          var operation = wsdl.definitions.bindings.ICD9Soap.operations.GetICD9Level2; // eslint-disable-line max-len
+          var operation = wsdl.definitions.bindings.AddressLookupSoap.operations.CheckAddressW2lines; // eslint-disable-line max-len
           operations.push(operation);
           loadedWsdl = wsdl;
           var apiData = {
@@ -364,8 +363,8 @@ describe('Generate APIs and models with WSDLs containing ', function() {
             'datasource': 'soapDS',
             'wsdl': wsdl,
             'wsdlUrl': url,
-            'service': 'ICD9',
-            'binding': 'ICD9Soap',
+            'service': 'AddressLookup',
+            'binding': 'AddressLookupSoap',
             'operations': operations,
           };
 
@@ -376,7 +375,7 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           assert.ok(index > -1);
           index = code.indexOf("soapDataSource.once('connected', function ()");
           assert.ok(index > -1);
-          index = code.indexOf('ICD9ICD9Soap.GetICD9Level2(GetICD9Level2, function (err, response)'); // eslint-disable-line max-len
+          index = code.indexOf('AddressLookupSoap.CheckAddressW2lines(CheckAddressW2lines, function (err, response)'); // eslint-disable-line max-len
           assert.ok(index > -1);
           done();
         });


### PR DESCRIPTION
### Description
Since the ICD9 wsdl in webserviceX.net does not exist, this PR fixes the test cases by using a new endpoint. 

#### Related issues
https://github.com/strongloop/loopback-soap/issues/14
