### PR TITLE
Check RPC lit wsdls for complex types

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -242,11 +242,13 @@ function getModels(wsdl, operations) {
 
   var models = {};
   let complexTypes, simpleTypes;
+  const complexTypesDescribe = {};
   for (let uri in schema) {
     complexTypes = schema[uri].complexTypes;
     if (complexTypes) {
       for (let type in complexTypes) {
         complexTypes[type].describeChildren(wsdl.definitions);
+        complexTypesDescribe[type] = complexTypes[type].describe(wsdl.definitions);
       }
     }
     simpleTypes = schema[uri].simpleTypes;
@@ -254,6 +256,7 @@ function getModels(wsdl, operations) {
   var schemaTypes = {
     complexTypes: complexTypes,
     simpleTypes: simpleTypes,
+    complexTypesDescribe: complexTypesDescribe,
   };
 
   for (let name in operations) {
@@ -261,21 +264,28 @@ function getModels(wsdl, operations) {
     var op = operations[name];
     var operationDescriptor = op.describe(wsdl.definitions);
     var inputBodyDescriptor = operationDescriptor.input.body;
+    var inputMessage;
     var modelName;
     if (inputBodyDescriptor.qname) {
       modelName = inputBodyDescriptor.qname.name;
-    }        else { // this may be a case of default namespace. Fall back on using input message name
+      inputMessage = op.operation.input.message;
+    } else { // this may be a case of default namespace. Fall back on using input message name
       modelName = op.input.message.$name;
     }
-    buildElementProperties(models, modelName, {}, inputBodyDescriptor, schemaTypes);
+    buildElementProperties(models, modelName, {},
+      inputBodyDescriptor, schemaTypes, inputMessage);
+
     if (op.output) { // incase of one-way operation, there is no output
       var outputBodyDescriptor = operationDescriptor.output.body;
+      var outputMessage;
       if (outputBodyDescriptor.qname) {
         modelName = outputBodyDescriptor.qname.name;
-      }            else { // this may be a case of default namespace. Fall back on using input message name
+        outputMessage = op.operation.output.message;
+      } else { // this may be a case of default namespace. Fall back on using input message name
         modelName = op.output.message.$name;
       }
-      buildElementProperties(models, modelName, {}, outputBodyDescriptor, schemaTypes);
+      buildElementProperties(models, modelName, {},
+        outputBodyDescriptor, schemaTypes, outputMessage);
     }
   }
 
@@ -283,7 +293,8 @@ function getModels(wsdl, operations) {
 };
 
 // builds properties for input/output params. It recursively builds properties for elements defined in the schema
-function buildElementProperties(models, modelName, propertyList, outerElem, schemaTypes) {
+function buildElementProperties(models, modelName,
+                                propertyList, outerElem, schemaTypes, message) {
   models[modelName] = {
     'name': modelName,
     'properties': propertyList,
@@ -298,13 +309,26 @@ function buildElementProperties(models, modelName, propertyList, outerElem, sche
 
     if (!element.type && !element.isSimple) {
       modName = element.qname.name;
-      buildElementProperties(models, modName, {}, element, schemaTypes);
+      buildElementProperties(models, modName, {}, element, schemaTypes, message);
       // check refOriginal since 'type' is returned as 'undefined' if it's referenced in a nested imported schema
       if (element.refOriginal) {
         propertyData = {
           type: checkAndConvertToNumber(element.refOriginal.qname.name),
         };
         propertyList[element.qname.name] = propertyData;
+      } else {
+        // Check the type of the message part against known complex types and include in models
+        if (message) {
+          propertyList[modName] = {type: modName};
+          if (message.parts[modName] && message.parts[modName].type) {
+            const partType = message.parts[modName].type.$name;
+            const typeElement = schemaTypes.complexTypesDescribe[partType];
+            if (typeElement) {
+              buildElementProperties(models,
+                modName, {}, typeElement, schemaTypes, message);
+            }
+          }
+        }
       }
       continue;
     }

--- a/test/results/stockquoterpc_model.json
+++ b/test/results/stockquoterpc_model.json
@@ -1,0 +1,34 @@
+{
+  "setLastTradePrice": {
+    "name": "setLastTradePrice",
+    "properties": {
+      "tradePrice": {
+        "type": "tradePrice"
+      }
+    }
+  },
+  "tradePrice": {
+    "name": "tradePrice",
+    "properties": {
+      "tradePrice": {
+        "type": "number"
+      }
+    }
+  },
+  "setLastTradePriceResponse": {
+    "name": "setLastTradePriceResponse",
+    "properties": {
+      "result": {
+        "type": "result"
+      }
+    }
+  },
+  "result": {
+    "name": "result",
+    "properties": {
+      "result": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -413,6 +413,26 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           done();
         });
   });
+
+  it('RPC/Literal WSDL using complex types', function(done) {
+    var options = {};
+    var operations = [];
+    var url = './wsdls/stockquoterpc.wsdl';
+
+    WSDL.open(path.resolve(__dirname, url), options,
+        function(err, wsdl) {
+          var operation =
+          wsdl.definitions.bindings.StockQuoteSoapBindingRPC.operations.setLastTradePrice;
+          operations.push(operation);
+
+          var generatedModels = helper.generateModels(wsdl, operations);
+
+          var expectedModels = path.resolve(__dirname, './results/stockquoterpc_model.json');
+          expectedModels = require(expectedModels);
+          expect(generatedModels).to.deep.equal(expectedModels);
+          done();
+        });
+  });
 });
 
 function readModelJsonSync(name) {

--- a/test/wsdls/stockquoterpc.wsdl
+++ b/test/wsdls/stockquoterpc.wsdl
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+
+<!-- rpc/literal example -->
+
+<wsdl:definitions name="StockQuoteRPC"
+
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://example.com/stockquoterpc.wsdl"
+                  targetNamespace="http://example.com/stockquoterpc.wsdl"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+    <xsd:schema elementFormDefault="qualified"
+              targetNamespace="http://example.com/stockquoterpc.wsdl">
+
+
+                <xsd:complexType name="setLastTradePriceRequestType">
+                    <xsd:sequence>
+                        <xsd:element name="tradePrice" type="xsd:float"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+
+                <xsd:complexType name="setLastTradePriceResponseType">
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:boolean"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+
+        </xsd:schema>
+    </wsdl:types>
+
+
+    <wsdl:message name="myRequest">
+        <wsdl:part name="tradePrice"
+              type="tns:setLastTradePriceRequestType"/>
+    </wsdl:message>
+    <wsdl:message name="myResponse">
+        <wsdl:part name="result"
+              type="tns:setLastTradePriceResponseType"/>
+    </wsdl:message>
+
+    <wsdl:portType name="StockQuoteUpdater">
+        <wsdl:operation name="setLastTradePrice">
+            <wsdl:input message="tns:myRequest"/>
+            <wsdl:output message="tns:myResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+
+    <wsdl:binding name="StockQuoteSoapBindingRPC" type="tns:StockQuoteUpdater">
+        <soap:binding style="rpc"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="setLastTradePrice">
+            <soap:operation soapAction="http://example.com/StockQuoteUpdater"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="StockQuoteServiceRPC">
+        <wsdl:port name="StockQuotePortRPC" binding="tns:StockQuoteSoapBindingRPC">
+            <soap:address location="http://localhost:15099/stockquoterpc"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>
+


### PR DESCRIPTION
### Description
When generating a loopback model for an RPC/literal wsdl which uses complex type, the model isn't correctly generating. This PR includes an example wsdl /test/wsdls/stockquoterpc.wsdl. Currently calling `generateModels()` against this WSDL is generating a model of:
```
{
  "setLastTradePrice": {
    "name": "setLastTradePrice",
    "properties": {}
  },
  "tradePrice": {
    "name": "tradePrice",
    "properties": {}
  },
  "setLastTradePriceResponse": {
    "name": "setLastTradePriceResponse",
    "properties": {}
  },
  "result": {
    "name": "result",
    "properties": {}
  }
}
```
which is missing the actual type information that is required. Note that SOAP-UI  generates the following soap envelopes for this wsdl:
SOAP-UI request:
```
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:stoc="http://example.com/stockquoterpc.wsdl">
   <soapenv:Header/>
   <soapenv:Body>
      <stoc:setLastTradePrice>
         <tradePrice>
            <stoc:tradePrice>7.5</stoc:tradePrice>
         </tradePrice>
      </stoc:setLastTradePrice>
   </soapenv:Body>
</soapenv:Envelope>
```

SOAP-UI Response
```
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:stoc="http://example.com/stockquoterpc.wsdl">
   <soapenv:Header/>
   <soapenv:Body>
      <stoc:setLastTradePriceResponse>
         <result>
            <stoc:result>true</stoc:result>
         </result>
      </stoc:setLastTradePriceResponse>
   </soapenv:Body>
</soapenv:Envelope>
```

The function `buildElementProperties()` was getting to a point where it wasn't checking against any complex types. This wasn't an issue for wsdls which used an `element` in the `wsdl:part` e.g.
```
    <wsdl:message name="GetQuoteSoapIn">
        <wsdl:part name="parameters" element="tns:GetQuote"/>
    </wsdl:message>
```
as the information was inlined during the processing so it could be found correctly, however when the `wsdl:part` specified a `type` instead of an `element` then this wasn't the case and the set of complex types needed to be checked.
```
    <wsdl:message name="myRequest">
        <wsdl:part name="tradePrice"
              type="tns:setLastTradePriceRequestType"/>
    </wsdl:message>
```

This PR:
- Calls `describe` on each complexType and stores the result so it is in the correct format to be used in `buildElementProperties()`
- Includes details of the `wsdl:message` in the call to `buildElementProperties()` in order to find the type if required.
- Includes the complex type information in the model.
- Adds a test case to cover this scenario.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
