### PR TITLE
Add test case showing regression

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -351,10 +351,9 @@ function buildElementProperties(models, modelName,
       propertyList[element.qname.name] = propertyData;
     }
 
-    if (
-      element.elements.length != 0 &&
-      !models.hasOwnProperty(element.type.name)
-    ) {
+    // Code reverted under due to regression
+    // For details see PR https://github.com/strongloop/loopback-soap/pull/19
+    if (element.elements.length != 0) {
       modName = element.type.name;
       buildElementProperties(models, modName, {}, element, schemaTypes);
     }

--- a/test/results/getcase_model.json
+++ b/test/results/getcase_model.json
@@ -1,0 +1,50 @@
+{
+  "GetCaseRequest": {
+    "name": "GetCaseRequest",
+    "properties": {
+      "CallBackUrl": {
+        "type": "string"
+      },
+      "DeliverAsFile": {
+        "type": "boolean"
+      },
+      "DistributorNumber": {
+        "type": "string"
+      },
+      "Token": {
+        "type": "string"
+      }
+    }
+  },
+  "GetCaseResponse": {
+    "name": "GetCaseResponse",
+    "properties": {
+      "BatchCount": {
+        "type": "number"
+      },
+      "BatchSize": {
+        "type": "number"
+      },
+      "Message": {
+        "type": "Message"
+      },
+      "Success": {
+        "type": "boolean"
+      }
+    }
+  },
+  "Message": {
+    "name": "Message",
+    "properties": {
+      "Code": {
+        "type": "number"
+      },
+      "Text": {
+        "type": "string"
+      },
+      "Type": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -433,6 +433,26 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           done();
         });
   });
+
+  it('Test GetCase WSDL to avoid regressions', function(done) {
+    var options = {};
+    var operations = [];
+    var url = './wsdls/GetCase.wsdl';
+
+    WSDL.open(path.resolve(__dirname, url), options,
+        function(err, wsdl) {
+          var operation =
+          wsdl.definitions.bindings.soap.operations.GetCase;
+          operations.push(operation);
+
+          var generatedModels = helper.generateModels(wsdl, operations);
+
+          var expectedModels = path.resolve(__dirname, './results/getcase_model.json');
+          expectedModels = require(expectedModels);
+          expect(generatedModels).to.deep.equal(expectedModels);
+          done();
+        });
+  });
 });
 
 function readModelJsonSync(name) {

--- a/test/wsdls/GetCase.wsdl
+++ b/test/wsdls/GetCase.wsdl
@@ -1,0 +1,68 @@
+<wsdl:definitions
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:tns="http://gateway.example.com/v1/GetCase"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+    name="GetCaseV1"
+    targetNamespace="http://gateway.example.com/v1/GetCase">
+    <wsdl:types>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/"
+            attributeFormDefault="qualified"
+            elementFormDefault="qualified"
+            targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/">
+            <xs:simpleType name="char"><xs:restriction base="xs:int"/></xs:simpleType><xs:element name="duration" nillable="true" type="tns:duration"/>
+            <xs:simpleType name="duration">
+                <xs:restriction base="xs:duration"><xs:pattern value="\\-?P(\\d*D)?(T(\\d*H)?(\\d*M)?(\\d*(\\.\\d*)?S)?)?"/><xs:minInclusive value="-P10675199DT2H48M5.4775808S"/><xs:maxInclusive value="P10675199DT2H48M5.4775807S"/></xs:restriction>
+            </xs:simpleType><xs:element name="guid" nillable="true" type="tns:guid"/>
+            <xs:simpleType name="guid">
+                <xs:restriction base="xs:string"><xs:pattern value="[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{12}"/></xs:restriction>
+            </xs:simpleType><xs:attribute name="FactoryType" type="xs:QName"/><xs:attribute name="Id" type="xs:ID"/><xs:attribute name="Ref" type="xs:IDREF"/></xs:schema>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://gateway.example.com/v1/GetCase"><xs:import namespace="http://gateway.esri.com/v1/GetCase/Summary"/>
+            <xs:complexType name="GetCaseRequest">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="Token" nillable="true" type="xs:string"/>
+                    <xs:element name="DistributorNumber" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="DeliverAsFile" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="CallBackUrl" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType><xs:element name="GetCaseRequest" nillable="true" type="tns:GetCaseRequest"/>
+            <xs:complexType name="GetCaseResponse">
+                <xs:sequence>
+                    <xs:element name="Success" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="Message" nillable="true" type="tns:Message"/>
+                    <xs:element minOccurs="0" name="BatchSize" type="xs:int"/>
+                    <xs:element minOccurs="0" name="BatchCount" type="xs:int"/>
+                </xs:sequence>
+            </xs:complexType><xs:element name="GetCaseResponse" nillable="true" type="tns:GetCaseResponse"/>
+            <xs:complexType name="Message">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="Type" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="Code" type="xs:int"/>
+                    <xs:element minOccurs="0" name="Text" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType><xs:element name="Message" nillable="true" type="tns:Message"/></xs:schema>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://gateway.example.com/v1/GetCase/Summary" elementFormDefault="qualified" targetNamespace="http://gateway.example.com/v1/GetCase/Summary">
+            <xs:complexType name="ArrayOfitem">
+                <xs:sequence><xs:element minOccurs="0" maxOccurs="unbounded" name="item" nillable="true" type="tns:item"/></xs:sequence>
+            </xs:complexType><xs:element name="ArrayOfitem" nillable="true" type="tns:ArrayOfitem"/>
+            <xs:complexType name="item">
+                <xs:sequence><xs:element minOccurs="0" name="DistributorNumber" type="xs:long"/><xs:element minOccurs="0" name="CustomerNumber" type="xs:long"/><xs:element minOccurs="0" name="CaseNumber" nillable="true" type="xs:string"/><xs:element minOccurs="0" name="LegacyCaseNumber" nillable="true" type="xs:string"/></xs:sequence>
+            </xs:complexType><xs:element name="item" nillable="true" type="tns:item"/></xs:schema>
+    </wsdl:types>
+    <wsdl:message name="GetCaseRequest"><wsdl:part name="GetCaseRequest" element="tns:GetCaseRequest"/></wsdl:message>
+    <wsdl:message name="GetCaseResponse"><wsdl:part name="GetCaseResponse" element="tns:GetCaseResponse"/></wsdl:message>
+    <wsdl:portType name="GetCase">
+        <wsdl:operation name="GetCase"><wsdl:input wsaw:Action="GetCaseRequest" name="GetCaseRequest" message="tns:GetCaseRequest"/><wsdl:output wsaw:Action="GetCaseResponse" name="GetCaseResponse" message="tns:GetCaseResponse"/></wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="soap" type="tns:GetCase"><soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="GetCase"><soap12:operation soapAction="GetCaseRequest" style="document"/>
+            <wsdl:input name="GetCaseRequest"><soap12:body use="literal"/></wsdl:input>
+            <wsdl:output name="GetCaseResponse"><soap12:body use="literal"/></wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="GetCaseV1">
+        <wsdl:port name="soap" binding="tns:soap"><soap12:address location="https://gatewaystg.example.com/v1/GetCase/Service.svc/soap"/></wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
### Description
PR https://github.com/strongloop/loopback-soap/pull/12 has introduced a regression in `v1.1.0`. 

Under `v1.0.4` of `loopback-soap`, the GetCase wsdl (provided as a test case in this PR) was being correctly modeled as:
```
{
  "GetCaseRequest": {
    "name": "GetCaseRequest",
    "properties": {
      "CallBackUrl": {
        "type": "string"
      },
      "DeliverAsFile": {
        "type": "boolean"
      },
      "DistributorNumber": {
        "type": "string"
      },
      "Token": {
        "type": "string"
      }
    }
  },
  "GetCaseResponse": {
    "name": "GetCaseResponse",
    "properties": {
      "BatchCount": {
        "type": "number"
      },
      "BatchSize": {
        "type": "number"
      },
      "Message": {
        "type": "Message"
      },
      "Success": {
        "type": "boolean"
      }
    }
  },
  "Message": {
    "name": "Message",
    "properties": {
      "Code": {
        "type": "number"
      },
      "Text": {
        "type": "string"
      },
      "Type": {
        "type": "string"
      }
    }
  }
}
``` 

under the change introduce by PR https://github.com/strongloop/loopback-soap/pull/12 which was released in `v1.1.0` the same wsdl is now incorrectly producing a model of:
```
{
  "GetCaseRequest": {
    "name": "GetCaseRequest",
    "properties": {
      "GetCaseRequest": {
        "type": "GetCaseRequest"
      }
    }
  },
  "GetCaseResponse": {
    "name": "GetCaseResponse",
    "properties": {
      "GetCaseResponse": {
        "type": "GetCaseResponse"
      }
    }
  }
}
```

This PR doesn't undo the breaking change (I wanted to give the owners of this repo the chance to revert that PR if that is how they wanted to manage it), but it does deliver a test case showing the issue. This test would have passed before `v1.1.0`, but is failing at `v1.1.0`

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-soap/pull/12

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
