### PR TITLE
Make sure restriction element is checked for base type

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -334,12 +334,18 @@ function buildElementProperties(models, modelName,
     }
     // if simpleType, check in simpleTypes list. For e.g Enum could be of simpleType, but not xs: simple type
     if (element.type) {
-      if (schemaTypes.simpleTypes && schemaTypes.simpleTypes[element.type.name]) {
+      if (
+        schemaTypes.simpleTypes &&
+        schemaTypes.simpleTypes[element.type.name]
+      ) {
         if (schemaTypes.simpleTypes[element.type.name].union) {
-          type = schemaTypes.simpleTypes[element.type.name]
-                                        .union.children[0].children[0].base.$name;
+          type = getBaseNameForSimpleType(
+            schemaTypes.simpleTypes[element.type.name].union.children[0]
+          );
         } else {
-          type = schemaTypes.simpleTypes[element.type.name].children[0].base.$name;
+          type = getBaseNameForSimpleType(
+            schemaTypes.simpleTypes[element.type.name]
+          );
         }
       } else {
         // could be a complextype or xs: simple type
@@ -359,6 +365,15 @@ function buildElementProperties(models, modelName,
     }
   }
   return models;
+}
+
+function getBaseNameForSimpleType(simpleType) {
+  for (const i of simpleType.children) {
+    if (i.name === 'restriction') {
+      return i.base.$name;
+    }
+  }
+  return undefined;
 }
 
 // get operations in a specific format needed for code generation in model.ejs template

--- a/test/wsdls/GetCase.wsdl
+++ b/test/wsdls/GetCase.wsdl
@@ -12,14 +12,33 @@
             attributeFormDefault="qualified"
             elementFormDefault="qualified"
             targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/">
-            <xs:simpleType name="char"><xs:restriction base="xs:int"/></xs:simpleType><xs:element name="duration" nillable="true" type="tns:duration"/>
+            <xs:simpleType name="char">
+                <xs:restriction base="xs:int"/>
+            </xs:simpleType>
+            <xs:element name="duration" nillable="true" type="tns:duration"/>
             <xs:simpleType name="duration">
-                <xs:restriction base="xs:duration"><xs:pattern value="\\-?P(\\d*D)?(T(\\d*H)?(\\d*M)?(\\d*(\\.\\d*)?S)?)?"/><xs:minInclusive value="-P10675199DT2H48M5.4775808S"/><xs:maxInclusive value="P10675199DT2H48M5.4775807S"/></xs:restriction>
-            </xs:simpleType><xs:element name="guid" nillable="true" type="tns:guid"/>
+                <xs:annotation>
+                    <xs:documentation>Duration</xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:duration">
+                    <xs:pattern value="\\-?P(\\d*D)?(T(\\d*H)?(\\d*M)?(\\d*(\\.\\d*)?S)?)?"/>
+                    <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+                    <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:element name="guid" nillable="true" type="tns:guid"/>
             <xs:simpleType name="guid">
-                <xs:restriction base="xs:string"><xs:pattern value="[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{12}"/></xs:restriction>
-            </xs:simpleType><xs:attribute name="FactoryType" type="xs:QName"/><xs:attribute name="Id" type="xs:ID"/><xs:attribute name="Ref" type="xs:IDREF"/></xs:schema>
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://gateway.example.com/v1/GetCase"><xs:import namespace="http://gateway.esri.com/v1/GetCase/Summary"/>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{12}"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:attribute name="FactoryType" type="xs:QName"/>
+            <xs:attribute name="Id" type="xs:ID"/>
+            <xs:attribute name="Ref" type="xs:IDREF"/>
+        </xs:schema>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://gateway.example.com/v1/GetCase">
+            <xs:import namespace="http://gateway.esri.com/v1/GetCase/Summary"/>
             <xs:complexType name="GetCaseRequest">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="Token" nillable="true" type="xs:string"/>
@@ -27,7 +46,8 @@
                     <xs:element minOccurs="0" name="DeliverAsFile" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="CallBackUrl" nillable="true" type="xs:string"/>
                 </xs:sequence>
-            </xs:complexType><xs:element name="GetCaseRequest" nillable="true" type="tns:GetCaseRequest"/>
+            </xs:complexType>
+            <xs:element name="GetCaseRequest" nillable="true" type="tns:GetCaseRequest"/>
             <xs:complexType name="GetCaseResponse">
                 <xs:sequence>
                     <xs:element name="Success" type="xs:boolean"/>
@@ -35,34 +55,64 @@
                     <xs:element minOccurs="0" name="BatchSize" type="xs:int"/>
                     <xs:element minOccurs="0" name="BatchCount" type="xs:int"/>
                 </xs:sequence>
-            </xs:complexType><xs:element name="GetCaseResponse" nillable="true" type="tns:GetCaseResponse"/>
+            </xs:complexType>
+            <xs:element name="GetCaseResponse" nillable="true" type="tns:GetCaseResponse"/>
             <xs:complexType name="Message">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="Type" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="Code" type="xs:int"/>
                     <xs:element minOccurs="0" name="Text" nillable="true" type="xs:string"/>
                 </xs:sequence>
-            </xs:complexType><xs:element name="Message" nillable="true" type="tns:Message"/></xs:schema>
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://gateway.example.com/v1/GetCase/Summary" elementFormDefault="qualified" targetNamespace="http://gateway.example.com/v1/GetCase/Summary">
+            </xs:complexType>
+            <xs:element name="Message" nillable="true" type="tns:Message"/>
+        </xs:schema>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://gateway.example.com/v1/GetCase/Summary" elementFormDefault="qualified" targetNamespace="http://gateway.example.com/v1/GetCase/Summary">
             <xs:complexType name="ArrayOfitem">
-                <xs:sequence><xs:element minOccurs="0" maxOccurs="unbounded" name="item" nillable="true" type="tns:item"/></xs:sequence>
-            </xs:complexType><xs:element name="ArrayOfitem" nillable="true" type="tns:ArrayOfitem"/>
+                <xs:sequence>
+                    <xs:element minOccurs="0" maxOccurs="unbounded" name="item" nillable="true" type="tns:item"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:element name="ArrayOfitem" nillable="true" type="tns:ArrayOfitem"/>
             <xs:complexType name="item">
-                <xs:sequence><xs:element minOccurs="0" name="DistributorNumber" type="xs:long"/><xs:element minOccurs="0" name="CustomerNumber" type="xs:long"/><xs:element minOccurs="0" name="CaseNumber" nillable="true" type="xs:string"/><xs:element minOccurs="0" name="LegacyCaseNumber" nillable="true" type="xs:string"/></xs:sequence>
-            </xs:complexType><xs:element name="item" nillable="true" type="tns:item"/></xs:schema>
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="DistributorNumber" type="xs:long"/>
+                    <xs:element minOccurs="0" name="CustomerNumber" type="xs:long"/>
+                    <xs:element minOccurs="0" name="CaseNumber" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="LegacyCaseNumber" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:element name="item" nillable="true" type="tns:item"/>
+        </xs:schema>
     </wsdl:types>
-    <wsdl:message name="GetCaseRequest"><wsdl:part name="GetCaseRequest" element="tns:GetCaseRequest"/></wsdl:message>
-    <wsdl:message name="GetCaseResponse"><wsdl:part name="GetCaseResponse" element="tns:GetCaseResponse"/></wsdl:message>
+    <wsdl:message name="GetCaseRequest">
+        <wsdl:part name="GetCaseRequest" element="tns:GetCaseRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetCaseResponse">
+        <wsdl:part name="GetCaseResponse" element="tns:GetCaseResponse"/>
+    </wsdl:message>
     <wsdl:portType name="GetCase">
-        <wsdl:operation name="GetCase"><wsdl:input wsaw:Action="GetCaseRequest" name="GetCaseRequest" message="tns:GetCaseRequest"/><wsdl:output wsaw:Action="GetCaseResponse" name="GetCaseResponse" message="tns:GetCaseResponse"/></wsdl:operation>
+        <wsdl:operation name="GetCase">
+            <wsdl:input wsaw:Action="GetCaseRequest" name="GetCaseRequest" message="tns:GetCaseRequest"/>
+            <wsdl:output wsaw:Action="GetCaseResponse" name="GetCaseResponse" message="tns:GetCaseResponse"/>
+        </wsdl:operation>
     </wsdl:portType>
-    <wsdl:binding name="soap" type="tns:GetCase"><soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
-        <wsdl:operation name="GetCase"><soap12:operation soapAction="GetCaseRequest" style="document"/>
-            <wsdl:input name="GetCaseRequest"><soap12:body use="literal"/></wsdl:input>
-            <wsdl:output name="GetCaseResponse"><soap12:body use="literal"/></wsdl:output>
+    <wsdl:binding name="soap" type="tns:GetCase">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="GetCase">
+            <soap12:operation soapAction="GetCaseRequest" style="document"/>
+            <wsdl:input name="GetCaseRequest">
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="GetCaseResponse">
+                <soap12:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:service name="GetCaseV1">
-        <wsdl:port name="soap" binding="tns:soap"><soap12:address location="https://gatewaystg.example.com/v1/GetCase/Service.svc/soap"/></wsdl:port>
-    </wsdl:service>
+        <wsdl:port name="soap" binding="tns:soap">
+            <soap12:address location="https://gatewaystg.example.com/v1/GetCase/Service.svc/soap"/>
+        </wsdl:port>
+    </wsdl:service>undefined
 </wsdl:definitions>


### PR DESCRIPTION
### Description

Allow:
```xml
<xs:simpleType name="duration">
                <xs:annotation>
                    <xs:documentation>Duration</xs:documentation>
                </xs:annotation>
                <xs:restriction base="xs:duration">
                    <xs:pattern value="\\-?P(\\d*D)?(T(\\d*H)?(\\d*M)?(\\d*(\\.\\d*)?S)?)?"/>
                    <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
                    <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
                </xs:restriction>
            </xs:simpleType>
```
#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
