### PR TITLE
Use a var name that does not conflict with class name

### DIFF
--- a/lib/codegen/model.ejs
+++ b/lib/codegen/model.ejs
@@ -24,8 +24,8 @@ function printMethod(modelName) {
     return method + params.join(', ') + ') {';
 }
 
-function printOperation(modelName) {
-    var serviceName = modelName || 'Service';
+function printOperation() {
+    var serviceName = '_soapModel';
     var method = serviceName + '.' + op.operationId
             + '(' + op.operationId + ', function (err, response) {';
     return method;
@@ -49,11 +49,11 @@ var server = require('../../server/server');
 module.exports = function(<%- modelName || 'Model' %>) {
 
   var soapDataSource = server.datasources.<%- datasource %>;
-  var <%- modelName %>;
+  var _soapModel;
 
   soapDataSource.once('connected', function () {
     // Create the model
-    <%- modelName %> = soapDataSource.createModel('<%- modelName %>', {});
+    _soapModel = soapDataSource.createModel('<%- modelName %>', {});
   });
 
 <%
@@ -68,7 +68,7 @@ for(var i = 0; i < operations.length; i++) {
    * @returns {<%- op.returnType %>} callback containing error or result. Result is the response/soap body in JSON form.
    */
   <%- printMethod(modelName) %>
-      <%- printOperation(modelName) %>
+      <%- printOperation() %>
         var result = response;
         callback(err, result);
       });

--- a/test/test.js
+++ b/test/test.js
@@ -375,7 +375,7 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           assert.ok(index > -1);
           index = code.indexOf("soapDataSource.once('connected', function ()");
           assert.ok(index > -1);
-          index = code.indexOf('AddressLookupSoap.CheckAddressW2lines(CheckAddressW2lines, function (err, response)'); // eslint-disable-line max-len
+          index = code.indexOf('_soapModel.CheckAddressW2lines(CheckAddressW2lines, function (err, response)'); // eslint-disable-line max-len
           assert.ok(index > -1);
           done();
         });
@@ -407,7 +407,7 @@ describe('Generate APIs and models with WSDLs containing ', function() {
           var code = helper.generateRemoteMethods(apiData);
 
           // check variable name for the model is created correctly by substituting any special characters not acceptable in javascript variable with _
-          var index = code.indexOf('var RPCLiteralService_a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x;'); // eslint-disable-line max-len
+          var index = code.indexOf('RPCLiteralService_a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x'); // eslint-disable-line max-len
           assert.ok(index > -1);
 
           done();


### PR DESCRIPTION
### Description

The generated code has conflicting names for a var and class before this PR:

```js
'use strict';
var server = require('../../server/server');

module.exports = function(TrackServiceTrackServiceSoapBinding) {

  var soapDataSource = server.datasources.fedex;
  var TrackServiceTrackServiceSoapBinding;

  soapDataSource.once('connected', function () {
    // Create the model
    TrackServiceTrackServiceSoapBinding = soapDataSource.createModel('TrackServiceTrackServiceSoapBinding', {});
  });


  /**
   * track
   * @param {TrackRequest} TrackRequest TrackRequest
   * @callback {Function} callback Callback function
   * @returns {any} callback containing error or result. Result is the response/soap body in JSON form.
   */
  TrackServiceTrackServiceSoapBinding.track = function(TrackRequest, callback) {
      TrackServiceTrackServiceSoapBinding.track(track, function (err, response) {
        var result = response;
        callback(err, result);
      });
  }
```

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
