### PR TITLE
Drop Node.js 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.4",
   "description": "Integration between LoopBack and SOAP API specs",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
With Node.js 6.x reached end of life, we're dropping the support for it. 
