### PR TITLE
Avoid looping

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -241,8 +241,9 @@ function getModels(wsdl, operations) {
   var schema = wsdl.definitions.schemas;
 
   var models = {};
-  let complexTypes, simpleTypes;
+  let complexTypes, simpleTypes, elementTypes;
   const complexTypesDescribe = {};
+  const elementTypesDescribe = {};
   for (let uri in schema) {
     complexTypes = schema[uri].complexTypes;
     if (complexTypes) {
@@ -252,11 +253,19 @@ function getModels(wsdl, operations) {
       }
     }
     simpleTypes = schema[uri].simpleTypes;
+    elementTypes = schema[uri].elements;
+    if(elementTypes) {
+      for (let type in elementTypes) {
+        elementTypesDescribe[type] = elementTypes[type].describe(wsdl.definitions);
+      }
+    }
   }
+
   var schemaTypes = {
     complexTypes: complexTypes,
     simpleTypes: simpleTypes,
     complexTypesDescribe: complexTypesDescribe,
+    elementTypesDescribe: elementTypesDescribe
   };
 
   for (let name in operations) {
@@ -357,10 +366,18 @@ function buildElementProperties(models, modelName,
       propertyList[element.qname.name] = propertyData;
     }
 
-    // Code reverted under due to regression
-    // For details see PR https://github.com/strongloop/loopback-soap/pull/19
-    if (element.elements.length != 0) {
-      modName = element.type.name;
+    modName = element.type.name;
+    /*
+     * Stop recursing if:
+     * - there are no more elements
+     * - a model with this name already exists unless this is an element looking up a complex type with the same name
+     */
+    if (element.elements.length != 0 &&
+      (!models.hasOwnProperty(modName) ||
+        ((modelName === modName) &&
+          schemaTypes.elementTypesDescribe &&
+          schemaTypes.elementTypesDescribe[modelName]) )) {
+
       buildElementProperties(models, modName, {}, element, schemaTypes);
     }
   }

--- a/test/results/complexRef_model.json
+++ b/test/results/complexRef_model.json
@@ -1,0 +1,122 @@
+{
+  "APIObject": {
+    "name": "APIObject",
+    "properties": {
+      "MyName": {
+        "type": "string"
+      },
+      "Owner": {
+        "type": "Owner"
+      }
+    }
+  },
+  "APIProperty": {
+    "name": "APIProperty",
+    "properties": {
+      "Name": {
+        "type": "string"
+      },
+      "Value": {
+        "type": "string"
+      }
+    }
+  },
+  "AccountUser": {
+    "name": "AccountUser",
+    "properties": {
+      "Email": {
+        "type": "string"
+      },
+      "Name": {
+        "type": "string"
+      },
+      "UserID": {
+        "type": "string"
+      },
+      "UserPermissions": {
+        "type": "UserAccess"
+      }
+    }
+  },
+  "Owner": {
+    "name": "Owner",
+    "properties": {
+      "Address": {
+        "type": "string"
+      },
+      "Name": {
+        "type": "string"
+      },
+      "User": {
+        "type": "AccountUser"
+      }
+    }
+  },
+  "RetrieveRequest": {
+    "name": "RetrieveRequest",
+    "properties": {
+      "ObjectType": {
+        "type": "string"
+      },
+      "PartnerProperties": {
+        "type": "APIProperty"
+      },
+      "Properties": {
+        "type": "string"
+      },
+      "RepeatLastResult": {
+        "type": "boolean"
+      }
+    }
+  },
+  "RetrieveRequestMsg": {
+    "name": "RetrieveRequestMsg",
+    "properties": {
+      "RetrieveRequest": {
+        "type": "RetrieveRequest"
+      }
+    }
+  },
+  "RetrieveResponseMsg": {
+    "name": "RetrieveResponseMsg",
+    "properties": {
+      "OverallStatus": {
+        "type": "string"
+      },
+      "RequestID": {
+        "type": "string"
+      },
+      "Results": {
+        "type": "APIObject"
+      }
+    }
+  },
+  "UserAccess": {
+    "name": "UserAccess",
+    "properties": {
+      "Delete": {
+        "type": "number"
+      },
+      "Description": {
+        "type": "string"
+      },
+      "Name": {
+        "type": "string"
+      },
+      "Owner": {
+        "type": "Owner"
+      },
+      "Value": {
+        "type": "string"
+      }
+    }
+  },
+  "retrieveRequest": {
+    "name": "retrieveRequest",
+    "properties": {}
+  },
+  "retrieveResponse": {
+    "name": "retrieveResponse",
+    "properties": {}
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -452,6 +452,31 @@ describe('Generate APIs and models with WSDLs containing ', function() {
         done();
       });
   });
+
+  it('Test complexReferences WSDL to avoid going into a loop', function(done) {
+
+    /*
+     * This tests covers the scenario where a chain of objects end up making a reference to a parent
+     * e.g. APIObject -> UserAccess -> Owner -> AccountUser -> UserAccess
+     */
+    var options = {};
+    var operations = [];
+    var url = './wsdls/complexReferences.wsdl';
+
+    WSDL.open(path.resolve(__dirname, url), options,
+      function(err, wsdl) {
+        var operation =
+          wsdl.definitions.bindings.SoapBinding.operations.Retrieve;
+        operations.push(operation);
+
+        var generatedModels = helper.generateModels(wsdl, operations);
+
+        var expectedModels = path.resolve(__dirname, './results/complexRef_model.json');
+        expectedModels = require(expectedModels);
+        expect(generatedModels).to.deep.equal(expectedModels);
+        done();
+      });
+  });
 });
 
 function readModelJsonSync(name) {

--- a/test/wsdls/complexReferences.wsdl
+++ b/test/wsdls/complexReferences.wsdl
@@ -1,0 +1,111 @@
+<definitions targetNamespace="http://example.com/wsdl/myAPI" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://example.com/wsdl/myAPI">
+  <types>
+    <schema elementFormDefault="qualified" targetNamespace="http://example.com/wsdl/myAPI" version="1.0" xmlns="http://www.w3.org/2001/XMLSchema">
+      <complexType name="APIObject">
+        <sequence>
+          <element name="MyName" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="1" />
+          <element name="Owner" type="tns:Owner" minOccurs="0" maxOccurs="1" />
+        </sequence>
+      </complexType>
+      <complexType name="APIProperty">
+        <sequence>
+          <element name="Name" type="xsd:string" />
+          <element name="Value" type="xsd:string" />
+        </sequence>
+      </complexType>
+      <complexType name="Owner">
+        <sequence>
+          <element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1" />
+          <element name="Address" type="xsd:string" minOccurs="0" maxOccurs="1" />
+          <element name="User" type="tns:AccountUser" minOccurs="0" maxOccurs="1" />
+        </sequence>
+      </complexType>
+      <complexType name="Result">
+        <sequence>
+          <element name="StatusCode" type="xsd:string" />
+          <element name="StatusMessage" type="xsd:string" />
+        </sequence>
+      </complexType>
+      <complexType name="RetrieveRequest">
+        <sequence>
+          <element name="ObjectType" type="xsd:string" minOccurs="1" maxOccurs="1" />
+          <element name="Properties" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+          <element name="PartnerProperties" type="tns:APIProperty" minOccurs="0" maxOccurs="unbounded" />
+          <element name="RepeatLastResult" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+        </sequence>
+      </complexType>
+      <element name="RetrieveRequestMsg">
+        <complexType>
+          <sequence>
+            <element name="RetrieveRequest" type="tns:RetrieveRequest" minOccurs="1" maxOccurs="1" />
+          </sequence>
+        </complexType>
+      </element>
+      <element name="RetrieveResponseMsg">
+        <complexType>
+          <sequence>
+            <element name="OverallStatus" type="xsd:string" minOccurs="1" maxOccurs="1" />
+            <element name="RequestID" type="xsd:string" minOccurs="0" maxOccurs="1" />
+            <element name="Results" type="tns:APIObject" minOccurs="0" maxOccurs="unbounded" />
+          </sequence>
+        </complexType>
+      </element>
+      <complexType name="AccountUser">
+        <complexContent>
+          <extension base="tns:APIObject">
+            <sequence>
+              <element minOccurs="1" maxOccurs="1" name="UserID" type="xsd:string" />
+              <element minOccurs="1" maxOccurs="1" name="Name" type="xsd:string" />
+              <element minOccurs="1" maxOccurs="1" name="Email" type="xsd:string" />
+              <element minOccurs="0" maxOccurs="unbounded" name="UserPermissions" nillable="true" type="tns:UserAccess" />
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+      <complexType name="UserAccess">
+        <complexContent>
+          <extension base="tns:APIObject">
+            <sequence>
+              <element name="Name" nillable="true" minOccurs="0" maxOccurs="1" type="xsd:string" />
+              <element name="Value" nillable="true" minOccurs="0" maxOccurs="1" type="xsd:string" />
+              <element name="Description" nillable="true" minOccurs="0" maxOccurs="1" type="xsd:string" />
+              <element minOccurs="0" maxOccurs="unbounded" name="Owner" nillable="true" type="tns:Owner" />
+              <element name="Delete" minOccurs="1" maxOccurs="1" type="xsd:int" />
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+    </schema>
+  </types>
+  <message name="retrieveRequest">
+    <part element="tns:RetrieveRequestMsg" name="parameters" />
+  </message>
+  <message name="retrieveResponse">
+    <part element="tns:RetrieveResponseMsg" name="parameters" />
+  </message>
+  <portType name="Soap">
+    <operation name="Retrieve">
+      <documentation>Retrieve objects</documentation>
+      <input message="tns:retrieveRequest" />
+      <output message="tns:retrieveResponse" />
+    </operation>
+  </portType>
+  <binding name="SoapBinding" type="tns:Soap">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+    <operation name="Retrieve">
+      <soap:operation soapAction="Retrieve" />
+      <input>
+        <soap:body parts="parameters" use="literal" />
+      </input>
+      <output>
+        <soap:body use="literal" />
+      </output>
+    </operation>
+  </binding>
+  <service name="MyAPI">
+    <documentation>My API</documentation>
+    <port binding="tns:SoapBinding" name="Soap">
+      <soap:address location="https://example.com/Service.asmx" />
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
### Description
It is possible for `loopback-soap` to go into a loop when an element in a schema ends up referencing an element already in its chain. e.g `APIObject -> UserAccess -> Owner -> AccountUser -> UserAccess`

This can result in the error:
```

\"Maximum call stack size exceeded\",\"name\":\"RangeError\",\"stack\":\"RangeError:  Maximum call stack size exceeded\\n    at write (console.js:168:9)\\n    at Console.log (console.js:200:3)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:381:15)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\ \\\codegen\\\\generator-soap.js:382:7)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\ generator-soap.js:382:7)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap .js:382:7)\\n    at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n     at buildElementProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n    at buildEle mentProperties (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n    at buildElementProperties  (C:\\\\loopback-soap\\\\lib\\\\codegen\\\\generator-soap.js:382:7)\\n......
```

This had originally been identified in issue https://github.com/strongloop/loopback-soap/pull/10, however PR https://github.com/strongloop/loopback-soap/pull/12 caused a regression (see PR https://github.com/strongloop/loopback-soap/pull/19 for details) and was reverted. 

This PR performs a similar fix, but with some additional checks to avoid the original regression. 

The original fix was to check the list of models that had already been processed and if a model with the same name exists then stop the recursion. This PR builds on top of that but also to cover the case where an `element` pointed to a `complexType` which had the same name, as is the case in [here].(https://github.com/strongloop/loopback-soap/blob/master/test/wsdls/GetCase.wsdl#L50)

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-soap/pull/10
- connect to https://github.com/strongloop/loopback-soap/pull/12
- connect to https://github.com/strongloop/loopback-soap/pull/19

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
