### PR TITLE
Put var assignment back inside if

### DIFF
--- a/lib/codegen/generator-soap.js
+++ b/lib/codegen/generator-soap.js
@@ -366,18 +366,19 @@ function buildElementProperties(models, modelName,
       propertyList[element.qname.name] = propertyData;
     }
 
-    modName = element.type.name;
     /*
      * Stop recursing if:
      * - there are no more elements
      * - a model with this name already exists unless this is an element looking up a complex type with the same name
      */
-    if (element.elements.length != 0 &&
-      (!models.hasOwnProperty(modName) ||
+    if (element.elements.length != 0) {
+      modName = element.type.name;
+      if (!models.hasOwnProperty(modName) ||
         ((modelName === modName) &&
           schemaTypes.elementTypesDescribe &&
-          schemaTypes.elementTypesDescribe[modelName]))) {
-      buildElementProperties(models, modName, {}, element, schemaTypes);
+          schemaTypes.elementTypesDescribe[modelName])) {
+        buildElementProperties(models, modName, {}, element, schemaTypes);
+      }
     }
   }
   return models;


### PR DESCRIPTION
### Description
Pr https://github.com/strongloop/loopback-soap/pull/28 moved the assignment of variable `modName = element.type.name;` to outside of an `if` statement, leaving an edge case where the value of `element.type` could be `undefined`. 

This PR moves the variable assignment back inside the original `if` statement as it was previously.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-soap/pull/28

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
