### PR TITLE
Update ejs to v3.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "ejs": "^2.5.5",
+    "ejs": "^3.1.7",
     "lodash": "^4.17.11",
     "underscore.string": "^3.3.5"
   }


### PR DESCRIPTION
### Description
`loopback-soap` is pulling in an old version of `ejs`, which contains security vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29078.

This PR updates `ejs` to v3.1.7 which does not have the vulnerability.

#### Related issues

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
